### PR TITLE
Correct flush of data to clickhouse after sending "STOP signal"

### DIFF
--- a/backuper.go
+++ b/backuper.go
@@ -1,0 +1,6 @@
+package main
+
+// Dump - save query to file
+func Dump(params string, data string) {
+
+}

--- a/clickhouse.go
+++ b/clickhouse.go
@@ -77,17 +77,6 @@ func (c *Clickhouse) GetNextServer() (srv *ClickhouseServer) {
 
 }
 
-// Send - send request to next server
-func (c *Clickhouse) Send(queryString string, data string) {
-	req := ClickhouseRequest{queryString, data}
-	c.Queue.Put(req)
-}
-
-// Dump - save query to file
-func (c *Clickhouse) Dump(params string, data string) {
-
-}
-
 // Run server
 func (c *Clickhouse) Run() {
 	var err error
@@ -99,7 +88,7 @@ func (c *Clickhouse) Run() {
 			resp, status := c.SendQuery(data.Params, data.Content)
 			if status != http.StatusOK {
 				log.Printf("Send ERROR %+v: %+v\n", status, resp)
-				c.Dump(data.Params, data.Content)
+				Dump(data.Params, data.Content)
 			}
 		}
 	}

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"net/http"
 	"testing"
-	"time"
 )
 
 func TestClickhouse_GetNextServer(t *testing.T) {
@@ -23,15 +22,6 @@ func TestClickhouse_GetNextServer(t *testing.T) {
 	assert.Equal(t, http.StatusBadGateway, status)
 	assert.Equal(t, true, s.Bad)
 	c.SendQuery("", "")
-}
-
-func TestClickhouse_Send(t *testing.T) {
-	c := NewClickhouse(300)
-	c.AddServer("")
-	c.Send("", "")
-	for !c.Queue.Empty() {
-		time.Sleep(10)
-	}
 }
 
 func TestClickhouse_SendQuery(t *testing.T) {

--- a/collector.go
+++ b/collector.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"log"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strings"
@@ -59,7 +61,11 @@ func (t *Table) Content() string {
 // Flush - sends collcted data in table to clickhouse
 func (t *Table) Flush() {
 	rows := t.Content()
-	t.Sender.Send(t.Name, rows)
+	resp, status := t.Sender.SendQuery(t.Name, rows)
+	if status != http.StatusOK {
+		log.Printf("Flush ERROR %+v: %+v\n", status, resp)
+		Dump(t.Name, rows)
+	}
 	t.Rows = make([]string, 0, t.FlushCount)
 	t.Count = 0
 }

--- a/sender.go
+++ b/sender.go
@@ -4,13 +4,10 @@ import "net/http"
 
 // Sender interface for send requests
 type Sender interface {
-	Send(queryString string, data string)
 	SendQuery(queryString string, data string) (response string, status int)
 }
 
 type fakeSender struct{}
-
-func (s *fakeSender) Send(queryString string, data string) {}
 
 func (s *fakeSender) SendQuery(queryString string, data string) (response string, status int) {
 	return "", http.StatusOK


### PR DESCRIPTION
There are some problems with sending "STOP signal".

1. After sending "STOP signal" POST query not works. Insert data is lost. If I use standart SendQuery instead of Send method everything is ok. If I put Sleep into Send befor flushing it the table it is also ok. 
2. It is unclear whether the data was flushed to the clickhouse

I propose the following solution.