### PR TITLE
collector: fix data race

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 
 script:
   - go get -t -v
-  - go test -v -covermode=count -coverprofile=coverage.out
+  - go test -race -v -covermode=count -coverprofile=coverage.out
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 
 script:
   - go get -t -v
-  - go test -race -v -covermode=count -coverprofile=coverage.out
+  - go test -race -v -covermode=atomic -coverprofile=coverage.out
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/collector.go
+++ b/collector.go
@@ -56,7 +56,7 @@ func (t *Table) Content() string {
 	return strings.Join(t.Rows, "\n")
 }
 
-// Flush - sends collcted data in table to clickhouse
+// Flush - sends collected data in table to clickhouse
 func (t *Table) Flush() {
 	rows := t.Content()
 	t.Sender.Send(t.Name, rows)
@@ -137,19 +137,25 @@ func (c *Collector) WaitFlush() (err error) {
 
 // AddTable - adding table to collector
 func (c *Collector) AddTable(name string) {
-	t := NewTable(name, c.Sender, c.Count, c.FlushInterval)
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	c.addTable(name)
+}
+
+func (c *Collector) addTable(name string) {
+	t := NewTable(name, c.Sender, c.Count, c.FlushInterval)
 	c.Tables[name] = t
 	t.RunTimer()
 }
 
 // Push - adding query to collector with query params (with query) and rows
 func (c *Collector) Push(params string, content string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	_, ok := c.Tables[params]
 	if !ok {
 		//log.Printf("'%+v'\n", params)
-		c.AddTable(params)
+		c.addTable(params)
 	}
 	c.Tables[params].Add(content)
 }


### PR DESCRIPTION
Hello and thank you for the great project!

Just found that `Collector.Push` is not "goroutine safe".
You can check it by passing `-race` flag to the `go test` command:

```
> go test -race .
2019/02/18 17:41:29 send 1 rows to http://127.0.0.1:8124 of 
2019/02/18 17:41:29 send 1 rows to http://127.0.0.1:8125 of 
2019/02/18 17:41:29 send 1 rows to http://127.0.0.1:8123 of 
==================
WARNING: DATA RACE
Read at 0x00c000184810 by goroutine 39:
  runtime.mapaccess2_faststr()
      /home/lenstr/sdk/go1.11.5/src/runtime/map_faststr.go:101 +0x0
  github.com/lenstr/clickhouse-bulk.(*Collector).Push()
      /home/lenstr/Projects/clickhouse-bulk/collector.go:149 +0x6f

Previous write at 0x00c000184810 by goroutine 37:
  runtime.mapassign_faststr()
      /home/lenstr/sdk/go1.11.5/src/runtime/map_faststr.go:190 +0x0
  github.com/lenstr/clickhouse-bulk.(*Collector).AddTable()
      /home/lenstr/Projects/clickhouse-bulk/collector.go:143 +0x1c2
  github.com/lenstr/clickhouse-bulk.(*Collector).Push()
      /home/lenstr/Projects/clickhouse-bulk/collector.go:152 +0x125
...

```