### PR TITLE
add TLS options: serverName & skip verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ClickHouse-Bulk
- 
+
 [![Build Status](https://travis-ci.org/nikepan/clickhouse-bulk.svg?branch=master)](https://travis-ci.org/nikepan/clickhouse-bulk)
 [![codecov](https://codecov.io/gh/nikepan/clickhouse-bulk/branch/master/graph/badge.svg)](https://codecov.io/gh/nikepan/clickhouse-bulk)
 [![download binaries](https://img.shields.io/badge/binaries-download-blue.svg)](https://github.com/nikepan/clickhouse-bulk/releases)
@@ -35,7 +35,7 @@ go build
 - Supports query in query parameters and in body
 - Supports other query parameters like username, password, database
 - Supports basic authentication
- 
+
 
 For example:
 ```sql
@@ -55,15 +55,19 @@ INSERT INTO table3 (c1, c2, c3) VALUES ('v1', 'v2', 'v3')('v4', 'v5', 'v6')
 ### Configuration file
 ```javascript
 {
-  "listen": ":8124", 
+  "listen": ":8124",
   "flush_count": 10000, // check by \n char
   "flush_interval": 1000, // milliseconds
+  "clean_interval": 0, // how often cleanup internal tables - e.g. inserts to different temporary tables, or as workaround for query_id etc. milliseconds
+  "remove_query_id": true, // some drivers sends query_id which prevents inserts to be batched
   "dump_check_interval": 300, // interval for try to send dumps (seconds); -1 to disable
   "debug": false, // log incoming requests
   "dump_dir": "dumps", // directory for dump unsended data (if clickhouse errors)
   "clickhouse": {
     "down_timeout": 60, // wait if server in down (seconds)
     "connect_timeout": 10, // wait for server connect (seconds)
+    "tls_server_name": "", // override TLS serverName for certificate verification (e.g. in cases you share same "cluster" certificate across multiple nodes)
+    "insecure_tls_skip_verify": false, // INSECURE - skip certificate verification at all
     "servers": [
       "http://127.0.0.1:8123"
     ]
@@ -73,12 +77,16 @@ INSERT INTO table3 (c1, c2, c3) VALUES ('v1', 'v2', 'v3')('v4', 'v5', 'v6')
 
 ### Environment variables (used for docker image)
 
+* `CLICKHOUSE_BULK_DEBUG` - enable debug logging
 * `CLICKHOUSE_SERVERS` - comma separated list of servers
 * `CLICKHOUSE_FLUSH_COUNT` - count of rows for insert
 * `CLICKHOUSE_FLUSH_INTERVAL` - insert interval
+* `CLICKHOUSE_CLEAN_INTERVAL` - internal tables clean interval
 * `DUMP_CHECK_INTERVAL` - interval of resend dumps  
 * `CLICKHOUSE_DOWN_TIMEOUT` - wait time if server is down  
 * `CLICKHOUSE_CONNECT_TIMEOUT` - clickhouse server connect timeout  
+* `CLICKHOUSE_TLS_SERVER_NAME` - server name for TLS certificate verification
+* `CLICKHOUSE_INSECURE_TLS_SKIP_VERIFY` - skip certificate verification at all
 
 ### Quickstart
 

--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestClickhouse_GetNextServer(t *testing.T) {
-	c := NewClickhouse(300, 10)
+	c := NewClickhouse(300, 10, "", false)
 	c.AddServer("")
 	c.AddServer("http://127.0.0.1:8124")
 	c.AddServer("http://127.0.0.1:8125")
@@ -29,7 +29,7 @@ func TestClickhouse_GetNextServer(t *testing.T) {
 }
 
 func TestClickhouse_Send(t *testing.T) {
-	c := NewClickhouse(300, 10)
+	c := NewClickhouse(300, 10, "", false)
 	c.AddServer("")
 	c.Send(&ClickhouseRequest{})
 	for !c.Queue.Empty() {
@@ -38,7 +38,7 @@ func TestClickhouse_Send(t *testing.T) {
 }
 
 func TestClickhouse_SendQuery(t *testing.T) {
-	c := NewClickhouse(300, 10)
+	c := NewClickhouse(300, 10, "", false)
 	c.AddServer("")
 	c.GetNextServer()
 	c.Servers[0].Bad = true
@@ -48,7 +48,7 @@ func TestClickhouse_SendQuery(t *testing.T) {
 }
 
 func TestClickhouse_SendQuery1(t *testing.T) {
-	c := NewClickhouse(-1, 10)
+	c := NewClickhouse(-1, 10, "", false)
 	c.AddServer("")
 	c.GetNextServer()
 	c.Servers[0].Bad = true

--- a/config.sample.json
+++ b/config.sample.json
@@ -10,6 +10,8 @@
   "clickhouse": {
     "down_timeout": 60,
     "connect_timeout": 10,
+    "tls_server_name": "",
+    "insecure_tls_skip_verify": false,
     "servers": [
       "http://127.0.0.1:8123"
     ]

--- a/dump_test.go
+++ b/dump_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestDump_Dump(t *testing.T) {
-	c := NewClickhouse(-1, 10)
+	c := NewClickhouse(-1, 10, "", false)
 	dumpDir := "dumptest"
 	dumper := NewDumper(dumpDir)
 	c.Dumper = dumper

--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,6 @@ require (
 	github.com/labstack/gommon v0.2.8 // indirect
 	github.com/mattn/go-colorable v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.4 // indirect
-	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
-	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nikepan/go-datastructures v1.0.32
 	github.com/prometheus/client_golang v1.1.0
 	github.com/stretchr/testify v1.3.0

--- a/server.go
+++ b/server.go
@@ -135,7 +135,7 @@ func SafeQuit(collect *Collector, sender Sender) {
 func RunServer(cnf Config) {
 	InitMetrics()
 	dumper := NewDumper(cnf.DumpDir)
-	sender := NewClickhouse(cnf.Clickhouse.DownTimeout, cnf.Clickhouse.ConnectTimeout)
+	sender := NewClickhouse(cnf.Clickhouse.DownTimeout, cnf.Clickhouse.ConnectTimeout, cnf.Clickhouse.tlsServerName, cnf.Clickhouse.tlsSkipVerify)
 	sender.Dumper = dumper
 	for _, url := range cnf.Clickhouse.Servers {
 		sender.AddServer(url)

--- a/server_test.go
+++ b/server_test.go
@@ -51,6 +51,14 @@ func TestRunServer(t *testing.T) {
 	status, _ = request("GET", "/metrics", "", server.echo)
 	assert.Equal(t, status, http.StatusOK)
 
+	server.echo.GET("/debug/gc", server.gcHandler)
+	status, resp = request("GET", "/debug/gc", "", server.echo)
+	assert.Equal(t, status, http.StatusOK)
+
+	server.echo.GET("/debug/freemem", server.freeMemHandler)
+	status, resp = request("GET", "/debug/freemem", "", server.echo)
+	assert.Equal(t, status, http.StatusOK)
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	server.Shutdown(ctx)
@@ -93,7 +101,7 @@ func TestServer_MultiServer(t *testing.T) {
 	}))
 	defer s2.Close()
 
-	sender := NewClickhouse(10, 10)
+	sender := NewClickhouse(10, 10, "", false)
 	sender.AddServer(s1.URL)
 	sender.AddServer(s2.URL)
 	collect := NewCollector(sender, 1000, 1000, 0, true)

--- a/utils.go
+++ b/utils.go
@@ -12,6 +12,8 @@ const sampleConfig = "config.sample.json"
 
 type clickhouseConfig struct {
 	Servers        []string `json:"servers"`
+	tlsServerName  string   `json:"tls_server_name"`
+	tlsSkipVerify  bool     `json:"insecure_tls_skip_verify"`
 	DownTimeout    int      `json:"down_timeout"`
 	ConnectTimeout int      `json:"connect_timeout"`
 }
@@ -87,12 +89,18 @@ func ReadConfig(configFile string) (Config, error) {
 	readEnvInt("DUMP_CHECK_INTERVAL", &cnf.DumpCheckInterval)
 	readEnvInt("CLICKHOUSE_DOWN_TIMEOUT", &cnf.Clickhouse.DownTimeout)
 	readEnvInt("CLICKHOUSE_CONNECT_TIMEOUT", &cnf.Clickhouse.ConnectTimeout)
+	readEnvBool("CLICKHOUSE_INSECURE_TLS_SKIP_VERIFY", &cnf.Clickhouse.tlsSkipVerify)
 
 	serversList := os.Getenv("CLICKHOUSE_SERVERS")
 	if serversList != "" {
 		cnf.Clickhouse.Servers = strings.Split(serversList, ",")
 	}
 	log.Printf("use servers: %+v\n", strings.Join(cnf.Clickhouse.Servers, ", "))
+
+	tlsServerName := os.Getenv("CLICKHOUSE_TLS_SERVER_NAME")
+	if tlsServerName != "" {
+		cnf.Clickhouse.tlsServerName = tlsServerName
+	}
 
 	return cnf, err
 }


### PR DESCRIPTION
imagine the situation you have a single DNS record pointing to multiple clickhouse nodes, but if a single one fails then that single endpoint get marked as down - bad - so you have to list your servers one by one, but what if your certificate CN is valid only for that cluster record - now you can use tlsServerName so you can use even IP addresses, or whatever you want as long as clickhouse server certificate CN matches tlsServerName