### PR TITLE
feat. wrap default prom registry for metrics name prefix by config

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,8 @@ INSERT INTO table3 (c1, c2, c3) VALUES ('v1', 'v2', 'v3')('v4', 'v5', 'v6')
     "servers": [
       "http://127.0.0.1:8123"
     ]
-  }
+  },
+  "metrics_prefix": "prefix"
 }
 ```
 
@@ -87,6 +88,7 @@ INSERT INTO table3 (c1, c2, c3) VALUES ('v1', 'v2', 'v3')('v4', 'v5', 'v6')
 * `CLICKHOUSE_CONNECT_TIMEOUT` - clickhouse server connect timeout  
 * `CLICKHOUSE_TLS_SERVER_NAME` - server name for TLS certificate verification
 * `CLICKHOUSE_INSECURE_TLS_SKIP_VERIFY` - skip certificate verification at all
+* `METRICS_PREFIX` - prefix for prometheus metrics
 
 ### Quickstart
 

--- a/metrics.go
+++ b/metrics.go
@@ -37,7 +37,8 @@ var queuedDumps = prometheus.NewGauge(
 	})
 
 // InitMetrics - init prometheus metrics
-func InitMetrics() {
+func InitMetrics(prefix string) {
+	prometheus.DefaultRegisterer = prometheus.WrapRegistererWithPrefix(prefix, prometheus.DefaultRegisterer)
 
 	prometheus.MustRegister(pushCounter)
 	prometheus.MustRegister(sentCounter)

--- a/server.go
+++ b/server.go
@@ -137,7 +137,7 @@ func SafeQuit(collect *Collector, sender Sender) {
 
 // RunServer - run all
 func RunServer(cnf Config) {
-	InitMetrics()
+	InitMetrics(cnf.MetricsPrefix)
 	dumper := NewDumper(cnf.DumpDir)
 	sender := NewClickhouse(cnf.Clickhouse.DownTimeout, cnf.Clickhouse.ConnectTimeout, cnf.Clickhouse.tlsServerName, cnf.Clickhouse.tlsSkipVerify)
 	sender.Dumper = dumper

--- a/utils.go
+++ b/utils.go
@@ -29,6 +29,7 @@ type Config struct {
 	DumpCheckInterval int              `json:"dump_check_interval"`
 	DumpDir           string           `json:"dump_dir"`
 	Debug             bool             `json:"debug"`
+	MetricsPrefix     string           `json:"metrics_prefix"`
 }
 
 // ReadJSON - read json file to struct
@@ -69,6 +70,13 @@ func readEnvBool(name string, value *bool) {
 	}
 }
 
+func readEnvString(name string, value *string) {
+	s := os.Getenv(name)
+	if s != "" {
+		*value = s
+	}
+}
+
 // ReadConfig init config data
 func ReadConfig(configFile string) (Config, error) {
 	cnf := Config{}
@@ -90,6 +98,7 @@ func ReadConfig(configFile string) (Config, error) {
 	readEnvInt("CLICKHOUSE_DOWN_TIMEOUT", &cnf.Clickhouse.DownTimeout)
 	readEnvInt("CLICKHOUSE_CONNECT_TIMEOUT", &cnf.Clickhouse.ConnectTimeout)
 	readEnvBool("CLICKHOUSE_INSECURE_TLS_SKIP_VERIFY", &cnf.Clickhouse.tlsSkipVerify)
+	readEnvString("METRICS_PREFIX", &cnf.MetricsPrefix)
 
 	serversList := os.Getenv("CLICKHOUSE_SERVERS")
 	if serversList != "" {


### PR DESCRIPTION
Added the ability to apply a prefix to metric names.

Reason. There is a need to specify different prefixes for different domain contexts for convenient search in grafana.