### PR TITLE
add log_queries option to hide sending/sent output from logs

### DIFF
--- a/clickhouse_test.go
+++ b/clickhouse_test.go
@@ -11,10 +11,10 @@ import (
 
 func TestClickhouse_GetNextServer(t *testing.T) {
 	c := NewClickhouse(300, 10, "", false)
-	c.AddServer("")
-	c.AddServer("http://127.0.0.1:8124")
-	c.AddServer("http://127.0.0.1:8125")
-	c.AddServer("http://127.0.0.1:8123")
+	c.AddServer("", true)
+	c.AddServer("http://127.0.0.1:8124", true)
+	c.AddServer("http://127.0.0.1:8125", true)
+	c.AddServer("http://127.0.0.1:8123", true)
 	s := c.GetNextServer()
 	assert.Equal(t, "", s.URL)
 	s.SendQuery(&ClickhouseRequest{})
@@ -30,7 +30,7 @@ func TestClickhouse_GetNextServer(t *testing.T) {
 
 func TestClickhouse_Send(t *testing.T) {
 	c := NewClickhouse(300, 10, "", false)
-	c.AddServer("")
+	c.AddServer("", true)
 	c.Send(&ClickhouseRequest{})
 	for !c.Queue.Empty() {
 		time.Sleep(10)
@@ -39,7 +39,7 @@ func TestClickhouse_Send(t *testing.T) {
 
 func TestClickhouse_SendQuery(t *testing.T) {
 	c := NewClickhouse(300, 10, "", false)
-	c.AddServer("")
+	c.AddServer("", true)
 	c.GetNextServer()
 	c.Servers[0].Bad = true
 	_, status, err := c.SendQuery(&ClickhouseRequest{})
@@ -49,7 +49,7 @@ func TestClickhouse_SendQuery(t *testing.T) {
 
 func TestClickhouse_SendQuery1(t *testing.T) {
 	c := NewClickhouse(-1, 10, "", false)
-	c.AddServer("")
+	c.AddServer("", true)
 	c.GetNextServer()
 	c.Servers[0].Bad = true
 	s := c.GetNextServer()

--- a/config.sample.json
+++ b/config.sample.json
@@ -6,6 +6,7 @@
   "remove_query_id": true,
   "dump_check_interval": 300,
   "debug": false,
+  "log_queries": true,
   "dump_dir": "dumps",
   "clickhouse": {
     "down_timeout": 60,

--- a/doc.go
+++ b/doc.go
@@ -45,6 +45,7 @@ Configuration file
   "flush_count": 10000, // check by \n char
   "flush_interval": 1000, // milliseconds
   "debug": false, // log incoming requests
+  "log_queries": true, // log "Sending/sent x rows to" messages for each query
   "dump_dir": "dumps", // directory for dump unsended data (if clickhouse errors)
   "clickhouse": {
     "down_timeout": 300, // wait if server in down (seconds)

--- a/dump_test.go
+++ b/dump_test.go
@@ -14,7 +14,7 @@ func TestDump_Dump(t *testing.T) {
 	dumpDir := "dumptest"
 	dumper := NewDumper(dumpDir)
 	c.Dumper = dumper
-	c.AddServer("")
+	c.AddServer("", true)
 	c.Dump("eee", "eee", "error", "", 502)
 	assert.True(t, c.Empty())
 	buf, _, err := dumper.GetDumpData(dumper.dumpName(1, "", 502))

--- a/server_test.go
+++ b/server_test.go
@@ -20,7 +20,7 @@ import (
 func TestRunServer(t *testing.T) {
 	cnf, _ := ReadConfig("wrong_config.json")
 	collector := NewCollector(&fakeSender{}, 1000, 1000, 0, true)
-	server := InitServer("", collector, false)
+	server := InitServer("", collector, false, true)
 	go server.Start(cnf)
 	server.echo.POST("/", server.writeHandler)
 
@@ -107,8 +107,8 @@ func TestServer_MultiServer(t *testing.T) {
 	defer s2.Close()
 
 	sender := NewClickhouse(10, 10, "", false)
-	sender.AddServer(s1.URL)
-	sender.AddServer(s2.URL)
+	sender.AddServer(s1.URL, true)
+	sender.AddServer(s2.URL, true)
 	collect := NewCollector(sender, 1000, 1000, 0, true)
 	collect.AddTable("test")
 	collect.Push("eee", "eee")

--- a/utils.go
+++ b/utils.go
@@ -29,6 +29,7 @@ type Config struct {
 	DumpCheckInterval int              `json:"dump_check_interval"`
 	DumpDir           string           `json:"dump_dir"`
 	Debug             bool             `json:"debug"`
+	LogQueries		    bool             `json:"log_queries"`
 	MetricsPrefix     string           `json:"metrics_prefix"`
 	UseTLS            bool             `json:"use_tls"`
 	TLSCertFile				string           `json:"tls_cert_file"`
@@ -102,6 +103,7 @@ func ReadConfig(configFile string) (Config, error) {
 	readEnvInt("CLICKHOUSE_CONNECT_TIMEOUT", &cnf.Clickhouse.ConnectTimeout)
 	readEnvBool("CLICKHOUSE_INSECURE_TLS_SKIP_VERIFY", &cnf.Clickhouse.tlsSkipVerify)
 	readEnvString("METRICS_PREFIX", &cnf.MetricsPrefix)
+	readEnvBool("LOG_QUERIES", &cnf.LogQueries)
 
 	serversList := os.Getenv("CLICKHOUSE_SERVERS")
 	if serversList != "" {


### PR DESCRIPTION
This PR adds the described config from #63 which makes the output configurable so one can disable the `Sending x rows to <server> of INSERT INTO x` from their logs.

Tested it locally and it worked