### PR TITLE
Handle octet-stream for passthru and credentials in Reqest X-Headers

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -72,7 +72,7 @@ func NewCollector(sender Sender, count int, interval int, cleanInterval int, rem
 // Content - get text content of rowsfor query
 func (t *Table) Content() string {
 	rowDelimiter := "\n"
-	if t.Format == "RowBinary" {
+	if strings.HasPrefix(t.Format, "RowBinary") {
 		rowDelimiter = ""
 	}
 	return t.Query + "\n" + strings.Join(t.Rows, rowDelimiter)
@@ -81,11 +81,10 @@ func (t *Table) Content() string {
 // Flush - sends collected data in table to clickhouse
 func (t *Table) Flush() {
 	req := ClickhouseRequest{
-		Params:   t.Params,
-		Query:    t.Query,
-		Content:  t.Content(),
-		Count:    len(t.Rows),
-		isInsert: true,
+		Params:  t.Params,
+		Query:   t.Query,
+		Content: t.Content(),
+		Count:   len(t.Rows),
 	}
 	t.Sender.Send(&req)
 	t.Rows = make([]string, 0, t.FlushCount)

--- a/dump.go
+++ b/dump.go
@@ -162,7 +162,13 @@ func (d *FileDumper) ProcessNextDump(sender Sender) error {
 			query = lines[1]
 			data = strings.Join(lines[1:], "\n")
 		}
-		_, status, err := sender.SendQuery(&ClickhouseRequest{Params: params, Content: data, Query: query, Count: len(lines[2:]), isInsert: true})
+		cr := &ClickhouseRequest{
+			Params:  params,
+			Content: data,
+			Query:   query,
+			Count:   len(lines[2:]),
+		}
+		_, status, err := sender.SendQuery(cr)
 		if err != nil {
 			return fmt.Errorf("server error (%+v) %+v", status, err)
 		}

--- a/main.go
+++ b/main.go
@@ -23,9 +23,9 @@ func main() {
 		return
 	}
 
-	cnf, err := ReadConfig(*configFile)
+	err := ReadConfig(*configFile)
 	if err != nil {
 		log.Fatalf("ERROR: %+v\n", err)
 	}
-	RunServer(cnf)
+	RunServer()
 }

--- a/sender.go
+++ b/sender.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"log"
 	"net/http"
 	"sync"
@@ -10,9 +11,11 @@ import (
 type Sender interface {
 	Send(r *ClickhouseRequest)
 	SendQuery(r *ClickhouseRequest) (response string, status int, err error)
+	PassThru(req *http.Request, clientReqBody []byte) (res *http.Response, buf *bytes.Buffer)
 	Len() int64
 	Empty() bool
 	WaitFlush() (err error)
+	SetCreds(c *Credentials)
 }
 
 type fakeSender struct {
@@ -32,6 +35,9 @@ func (s *fakeSender) SendQuery(r *ClickhouseRequest) (response string, status in
 	log.Printf("DEBUG: send query: %+v\n", s.sendQueryHistory)
 	return "", http.StatusOK, nil
 }
+func (c *fakeSender) PassThru(req *http.Request, clientReqBody []byte) (res *http.Response, buf *bytes.Buffer) {
+	return
+}
 
 func (s *fakeSender) Len() int64 {
 	return 0
@@ -43,4 +49,7 @@ func (s *fakeSender) Empty() bool {
 
 func (s *fakeSender) WaitFlush() error {
 	return nil
+}
+
+func (s *fakeSender) SetCreds(c *Credentials) {
 }

--- a/server_test.go
+++ b/server_test.go
@@ -18,10 +18,10 @@ import (
 )
 
 func TestRunServer(t *testing.T) {
-	cnf, _ := ReadConfig("wrong_config.json")
+	_ = ReadConfig("wrong_config.json")
 	collector := NewCollector(&fakeSender{}, 1000, 1000, 0, true)
 	server := InitServer("", collector, false, true)
-	go server.Start(cnf)
+	go server.Start()
 	server.echo.POST("/", server.writeHandler)
 
 	status, resp := request("POST", "/", "", server.echo)
@@ -125,11 +125,11 @@ func TestServer_MultiServer(t *testing.T) {
 	assert.True(t, sender.Empty())
 
 	os.Setenv("DUMP_CHECK_INTERVAL", "10")
-	cnf, err := ReadConfig("wrong_config.json")
+	err := ReadConfig("wrong_config.json")
 	os.Unsetenv("DUMP_CHECK_INTERVAL")
 	assert.Nil(t, err)
 	assert.Equal(t, 10, cnf.DumpCheckInterval)
-	go RunServer(cnf)
+	go RunServer()
 	time.Sleep(1000)
 }
 


### PR DESCRIPTION
- Move config to global variable to let access it from any app scope
- Use stream to handle bytes properly jdbc driver fails to connect Clickhouse without this feature. To reproduce this bug try to connect Click via Bulk with DBreaver
- Handle creds in X-ClickHouse-* headers (borrowed this part  from [chproxy](https://github.com/contentsquare/chproxy))

Issues left with these changes (and before them): 
- if any part got dumped and service restated and do not receive any requests after the restart there is no way to resume dumped inserts, since service won't have creds stored. An options is to provide creds thru env var. 
- RowBinary inserts from dump fail at at some point due to string conversions while being parsed which leads to `response: Code: 33. DB::Exception: Cannot read all data. Bytes read: 423943. Bytes expected: 12213357.: (at row 215)`
