### PR TITLE
Fix HTTP response body resource leak causing EOF errors

### DIFF
--- a/clickhouse.go
+++ b/clickhouse.go
@@ -202,6 +202,7 @@ func (srv *ClickhouseServer) SendQuery(r *ClickhouseRequest) (response string, s
 			srv.Bad = true
 			return err.Error(), http.StatusBadGateway, ErrServerIsDown
 		}
+		defer resp.Body.Close()
 		if r.isInsert && srv.LogQueries {
 			log.Printf("INFO: sent %+v rows to %+v of %+v\n", r.Count, srv.URL, r.Query)
 		}


### PR DESCRIPTION
My consumers were experiencing `EOFError: end of file reached` errors when using clickhouse-bulk with frequent flushes.

Investigation revealed that HTTP response bodies were not beingclosed after reading, causing:
  - Connection pool exhaustion
  - EOF errors when ClickHouse or load balancers forcibly closed idle connections
  - Resource leaks in long-running processes

### Solution

Added `defer resp.Body.Close()` after the HTTP POST request in `SendQuery()` to properly close response bodies and release connections back to the pool.

### Testing

Added `TestClickhouse_ResponseBodyClosed` to verify response bodies are properly closed to validate fix and prevent future regressions.

This follows Go's standard HTTP client best practices for resource management.