### PR TITLE
Update/fix release tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,18 +9,17 @@ jobs:
   goreleaser:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      -
-        name: Set up Go
+
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: stable
-      -
-        name: Run GoReleaser
+          go-version-file: 'go.mod'
+
+      - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
           distribution: goreleaser

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v2
+      uses: actions/setup-go@v5
       with:
-        go-version: 1.24
+        go-version-file: 'go.mod'
 
     - name: Build
       run: go build ./...

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ dumps
 clickhouse-bulk
 debug
 check.py
+/dist

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,4 +1,5 @@
----
+version: 2
+
 project_name: clickhouse-bulk
 
 release:
@@ -8,12 +9,13 @@ release:
 
 builds:
   - binary: clickhouse-bulk
-    goos: &goos
+    goos:
       - darwin
       - windows
       - linux
-    goarch: &goarch
+    goarch:
       - amd64
+      - arm64
       - 386
     env:
       - CGO_ENABLED=0
@@ -27,8 +29,52 @@ archives:
   - name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}'
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ['zip']
     files:
       - config.sample.json
       - README.md
       - LICENSE
+
+dockers:
+  - image_templates:
+      - "nikepan/{{ .ProjectName }}:{{ .Tag }}-amd64"
+      - "nikepan/{{ .ProjectName }}:{{ .Version }}-amd64"
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    goos: linux
+    goarch: amd64
+    extra_files:
+      - config.sample.json
+    build_flag_templates:
+      - "--platform=linux/amd64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+  - image_templates:
+      - "nikepan/{{ .ProjectName }}:{{ .Tag }}-arm64"
+      - "nikepan/{{ .ProjectName }}:{{ .Version }}-arm64"
+    dockerfile: Dockerfile.goreleaser
+    use: buildx
+    goos: linux
+    goarch: arm64
+    extra_files:
+      - config.sample.json
+    build_flag_templates:
+      - "--platform=linux/arm64"
+      - "--label=org.opencontainers.image.created={{.Date}}"
+      - "--label=org.opencontainers.image.title={{.ProjectName}}"
+      - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+      - "--label=org.opencontainers.image.version={{.Version}}"
+
+docker_manifests:
+  - name_template: "nikepan/{{ .ProjectName }}:{{ .Tag }}"
+    image_templates:
+      - "nikepan/{{ .ProjectName }}:{{ .Tag }}-amd64"
+      - "nikepan/{{ .ProjectName }}:{{ .Tag }}-arm64"
+
+  - name_template: "nikepan/{{ .ProjectName }}:latest"
+    image_templates:
+      - "nikepan/{{ .ProjectName }}:{{ .Version }}-amd64"
+      - "nikepan/{{ .ProjectName }}:{{ .Version }}-arm64"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
-FROM golang:1.24 as builder
+FROM golang:1.24 AS builder
 
+ARG TARGETOS
+ARG TARGETARCH
 ARG GOPROXY
-ENV GOOS=linux \
-    GOARCH=amd64 \
+ENV GOOS=$TARGETOS \
+    GOARCH=$TARGETARCH \
     CGO_ENABLED=0 \
     GO111MODULE=on
 

--- a/Dockerfile.goreleaser
+++ b/Dockerfile.goreleaser
@@ -1,0 +1,8 @@
+FROM alpine:3
+RUN apk add ca-certificates
+WORKDIR /app
+RUN mkdir /app/dumps
+COPY config.sample.json .
+COPY clickhouse-bulk .
+EXPOSE 8123
+ENTRYPOINT ["./clickhouse-bulk", "-config=config.sample.json"]

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 )
 
 var version = "unknown"
+var commit = "unknown"
 var date = "unknown"
 
 func main() {
@@ -19,9 +20,11 @@ func main() {
 	flag.Parse()
 
 	if flag.Arg(0) == "version" {
-		log.Printf("clickhouse-bulk ver. %+v (%+v)\n", version, date)
+		log.Printf("clickhouse-bulk v%s (commit: %s, built: %s)\n", version, commit, date)
 		return
 	}
+
+	log.Printf("Starting clickhouse-bulk v%s (commit: %s, built: %s)\n", version, commit, date)
 
 	cnf, err := ReadConfig(*configFile)
 	if err != nil {

--- a/server.go
+++ b/server.go
@@ -38,7 +38,10 @@ type Status struct {
 
 // NewServer - create server
 func NewServer(listen string, collector *Collector, debug bool, logQueries bool) *Server {
-	return &Server{listen, collector, debug, logQueries, echo.New()}
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+	return &Server{listen, collector, debug, logQueries, e}
 }
 
 func (server *Server) writeHandler(c echo.Context) error {
@@ -176,6 +179,7 @@ func RunServer(cnf Config) {
 		dumper.Listen(sender, cnf.DumpCheckInterval)
 	}
 
+	log.Printf("Server starting on %s\n", cnf.Listen)
 	err := srv.Start(cnf)
 	if err != nil {
 		log.Printf("ListenAndServe: %+v\n", err)

--- a/utils.go
+++ b/utils.go
@@ -142,6 +142,6 @@ func ReadConfig(configFile string) (Config, error) {
 		cnf.Clickhouse.Servers = strings.Split(serversList, ",")
 	}
 
-	log.Printf("use servers: %+v", strings.Join(cnf.Clickhouse.Servers, ", "))
+	log.Printf("Using servers: %+v", strings.Join(cnf.Clickhouse.Servers, ", "))
 	return cnf, nil
 }


### PR DESCRIPTION
This PR updates the release pipeline and tidies up a few log messages.

* Migrates to GoReleaser v2 with multi-arch support (amd64 + arm64)
* Updates CI to current `actions/*` versions and auto-detects Go version from `go.mod`
* Adds minimal GoReleaser Dockerfile
* Enable GoReleaser to push to DockerHub (repo secret and variable required)
* Cleans up startup logs and Echo framework banner output

When tagged with `vx.x.x` it should cut build via GoReleaser, update Github released and push to DockerHub. 

It should all be backwards compatible but you may want to cherry-pick parts of this to fit your workflow

Two repo level items are required:
```
vars.DOCKERHUB_USERNAME
secrets.DOCKERHUB_TOKEN
```

### Changes

* **GitHub Actions**

  * Updated test workflow action versions
  * Use Golang version from `go.mod` in the `actions/setup-go` step
  * Added Docker builder to GoReleaser
  * Add Docker login step to allow GoReleaser to publish docker images to DockerHub (repo secret and variable are required to be set)

* **.goreleaser.yml**

  * Added `arm64` builds
  * Added multi-arch build output
  * Added OCI image labels and bundled `config.sample.json` everywhere
  * Cleaned up some issues from `goreleaser check`
  * Fixed goreleaser docker via `Dockerfile.goreleaser` - Alpine image for runtime as GoReleaser Docker support uses the binaries it builds

* **Docker**

  * standalone `Dockerfile` now honors `TARGETOS/TARGETARCH` for multi-arch

* **Other**

  * Version banner now shows version, commit, and build date passed in from GoReleaser
  * Echo server banner/port hidden as they're covered in other output
  * Servers message re-worded for consistency
  * Added build artifact GoReleaser dir `/dist` to `.gitignore`
